### PR TITLE
Fix symlink to native-lisp

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -49,6 +49,10 @@ let
               --replace '(emacs-repository-get-branch)' '"master"'
             '';
 
+            postFixup = old.postFixup + ''
+             ln -snf $out/lib/emacs/28.0.50/native-lisp $out/Applications/Emacs.app/Contents/native-lisp
+            '';
+
           }
         )
       )


### PR DESCRIPTION
test with  `nix-build`
output info:
```
 ./result/Applications/Emacs.app/Contents/MacOS/Emacs --version
GNU Emacs 28.0.50
Copyright (C) 2020 Free Software Foundation, Inc.
GNU Emacs comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of GNU Emacs
under the terms of the GNU General Public License.
For more information about these matters, see the file named COPYING
```