### PR TITLE
Update the hash oftramp-detect-wrapped-gvfsd.patch

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -38,7 +38,7 @@ let
                 pkgs.fetchpatch {
                   name = "tramp-detect-wrapped-gvfsd.patch";
                   url = "https://raw.githubusercontent.com/nix-community/emacs-overlay/master/patches/tramp-detect-wrapped-gvfsd.patch";
-                  sha256 = "19nywajnkxjabxnwyp8rgkialyhdpdpy26mxx6ryfl9ddx890rnc";
+                  sha256 = "1rvz725697md3ir618kkrccsxzd6n0p8yddq7rsh5jg8dbrvjvcx";
                 }
               )
             ];


### PR DESCRIPTION
Thank you for publishing this repository!
I noticed that the hash of "tramp-detect-wrapped-gvfsd.patch" seems to be outdated and `nix-env -iA emacsGccDarwin -f https://github.com/twlz0ne/nix-gccemacs-darwin/archive/master.zip` fails.
By this change, the command success again (in my repository).
I'm new to nix, so feel free to ignore this if I'm off the point.


